### PR TITLE
#23 Optimize MongoDB queries with indexes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,10 @@ LOCAL_PORT=3001
 MONGOBD_USER=
 MONGOBD_PASSWORD=
 
+# MongoDB connection pool size (optional, defaults: max=10, min=2)
+MONGO_MAX_POOL_SIZE=10
+MONGO_MIN_POOL_SIZE=2
+
 # Session Configuration
 SESSION_SECRET=your-session-secret-change-in-production
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,8 @@ TOKEN_REFRESH=...            # signs refresh tokens
 TOKEN_EXP_IN=...             # access token expiry
 SESSION_SECRET=...
 REDIS_URL=redis://localhost:6379   # optional; fallback to in-memory if absent
+MONGO_MAX_POOL_SIZE=10       # optional; MongoDB connection pool max size
+MONGO_MIN_POOL_SIZE=2        # optional; MongoDB connection pool min size
 ```
 
 ---

--- a/src/config/process.config.ts
+++ b/src/config/process.config.ts
@@ -27,6 +27,8 @@ const {
   TOKEN_EXP_IN,
   MONGO_URI,
   REDIS_URL,
+  MONGO_MAX_POOL_SIZE,
+  MONGO_MIN_POOL_SIZE,
 } = process.env;
 
 export {
@@ -40,4 +42,6 @@ export {
   TOKEN_REFRESH,
   TOKEN_EXP_IN,
   REDIS_URL,
+  MONGO_MAX_POOL_SIZE,
+  MONGO_MIN_POOL_SIZE,
 };

--- a/src/database/mongo.db.ts
+++ b/src/database/mongo.db.ts
@@ -6,7 +6,7 @@
 
 import mongoose, { Mongoose } from 'mongoose';
 
-import { MONGO_URI, MONGOBD_USER, MONGOBD_PASSWORD } from '@/config/process.config';
+import { MONGO_URI, MONGOBD_USER, MONGOBD_PASSWORD, MONGO_MAX_POOL_SIZE, MONGO_MIN_POOL_SIZE } from '@/config/process.config';
 import { _log } from '@/utils';
 
 class MongoDBConnection {
@@ -52,7 +52,10 @@ class MongoDBConnection {
   public async connect(): Promise<boolean> {
     try {
       const MONGO_URI = this.getMongoURI();
-      await mongoose.connect(MONGO_URI);
+      await mongoose.connect(MONGO_URI, {
+        maxPoolSize: Number(MONGO_MAX_POOL_SIZE) || 10,
+        minPoolSize: Number(MONGO_MIN_POOL_SIZE) || 2,
+      });
       this.isConnected = true;
       _log('[MongoDB] Connected!');
       return true;

--- a/src/models/award.model.ts
+++ b/src/models/award.model.ts
@@ -17,7 +17,7 @@ const schema = new Schema(
     link: { type: String, default: '', required: [false, 'Vui lòng nhập liên kết'] },
     images: { type: Array, of: String },
     description: { type: String, default: '', required: [false, 'Vui lòng nhập mô tả'] },
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', index: true },
   },
   { timestamps: true },
 );

--- a/src/models/candidate.model.ts
+++ b/src/models/candidate.model.ts
@@ -19,6 +19,9 @@ const schema = new Schema(
       lowercase: true,
       trim: true,
       match: [/^\S+@\S+\.\S+$/, 'Email không đúng định dạng'],
+      unique: true,
+      sparse: true,
+      index: true,
     },
     password: { type: String, default: '', required: [false, 'Password is required'] },
 

--- a/src/models/certificate.model.ts
+++ b/src/models/certificate.model.ts
@@ -19,7 +19,7 @@ const schema = new Schema(
     isNoExpiration: { type: Boolean, default: false },
     link: { type: String, default: '', required: [false, 'Vui lòng nhập liên kết'] },
     images: { type: Array, of: String },
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', index: true },
   },
   { timestamps: true },
 );

--- a/src/models/education.model.ts
+++ b/src/models/education.model.ts
@@ -17,7 +17,7 @@ const schema = new Schema(
     endDate: { type: Number, default: '', required: [false, 'Vui lòng nhập ngày kết thúc'] },
     description: { type: String, default: '', required: [false, 'Vui lòng nhập mô tả'] },
     isCurrent: { type: Boolean, default: false },
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', index: true },
   },
   { timestamps: true },
 );

--- a/src/models/experience.model.ts
+++ b/src/models/experience.model.ts
@@ -16,7 +16,7 @@ const schema = new Schema(
     endDate: { type: Number, default: '', required: [false, 'Vui lòng nhập ngày kết thúc'] },
     description: { type: String, default: '', required: [false, 'Vui lòng nhập mô tả'] },
     isCurrent: { type: Boolean, default: false },
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', index: true },
     skills: { type: Array, of: String },
   },
   { timestamps: true },

--- a/src/models/generalInformation.model.ts
+++ b/src/models/generalInformation.model.ts
@@ -12,7 +12,7 @@ import { foreignLanguageSchema, professionalSkillsSchema, personalSkills } from 
 
 const schema = new Schema(
   {
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', unique: true },
     /* vị trí mong muốn */
     positionDesired: { type: String, default: '', required: [false, 'Vui lòng nhập vị trí mong muốn'] },
     career: { type: String, default: '', required: [false, 'Vui lòng nhập nghề nghiệp'] },

--- a/src/models/project.model.ts
+++ b/src/models/project.model.ts
@@ -21,7 +21,7 @@ const schema = new Schema(
     isWorking: { type: Boolean, default: false },
     startDate: { type: Number, default: '', required: [false, 'Vui lòng nhập ngày bắt đầu'] },
     endDate: { type: Number, default: '', required: [false, 'Vui lòng nhập ngày kết thúc'] },
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', index: true },
   },
   { timestamps: true },
 );

--- a/src/models/reference.modal.ts
+++ b/src/models/reference.modal.ts
@@ -14,7 +14,7 @@ const schema = new Schema(
     phone: { type: String, default: '', required: [false, 'Vui lòng nhập Số điện thoại'] },
     company: { type: String, default: '', required: [false, 'Vui lòng nhập Công ty'] },
     position: { type: String, default: '', required: [false, 'Vui lòng nhập Vị trí công việc'] },
-    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate' },
+    candidateId: { type: ObjectId, required: [true, 'Vui lòng nhập ID ứng viên'], ref: 'candidate', index: true },
   },
   { timestamps: true },
 );


### PR DESCRIPTION
## Summary
- Add a unique+sparse index on `Candidate.email` (login, register duplicate-check, `/api/me/:email`, and public profile lookups all filter by email; the app already enforces uniqueness in `auth.service.ts` via a pre-create existence check).
- Add a single-field index on `candidateId` for every CV section model (`experience`, `education`, `award`, `certificate`, `project`, `reference`) — the dominant query pattern across the codebase is `find({ candidateId })` via `baseFindDocument`/`baseGetAll`.
- Add a unique index on `generalInformation.candidateId`, matching the existing one-document-per-candidate rule already enforced in `handlerCreate`.
- Reviewed every query call site (`services/index.ts`, `candidate_me/index.ts`, `auth.service.ts`, `candidate.service.ts`) — no compound indexes were needed since every query filters on a single field (`email`, `candidateId`, or `_id`, which is already indexed by default).
- Enable explicit MongoDB connection pooling (`maxPoolSize`/`minPoolSize` on `mongoose.connect()`), configurable via new `MONGO_MAX_POOL_SIZE`/`MONGO_MIN_POOL_SIZE` env vars (defaults 10/2). Documented in `.env.example` and `CLAUDE.md`.

## Test plan
- [x] `npm test` — identical result before/after (11/11 runnable tests pass; 6 suites fail on a pre-existing, unrelated `jsonwebtoken` native-module load issue in this environment)
- [x] `tsc --noEmit` under a `module: Node16` override — no new type errors (pre-existing `@/utils/querySafe` resolution errors are identical before/after)
- [ ] Verify indexes are actually created against a real MongoDB instance (not run — no DB available in this environment); Mongoose builds indexes automatically on model registration by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)