### PR TITLE
#22 Add Swagger/OpenAPI documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,8 @@ src/
 │   ├── cors.config.ts         # CORS: origin '*'
 │   ├── session.config.ts      # Express session config
 │   ├── joi.config.ts          # Shared Joi schemas (email, password, phone, etc.)
-│   └── regex.config.ts        # Password + phone regex
+│   ├── regex.config.ts        # Password + phone regex
+│   └── swagger.config.ts      # OpenAPI spec (swagger-jsdoc), served at /api-docs
 ├── database/
 │   └── mongo.db.ts            # Singleton MongoDB connection manager
 ├── middlewares/
@@ -192,6 +193,8 @@ Sections: `education`, `experience`, `award`, `certificate`, `project`, `referen
 | GET | `/health` | None | Health check |
 | GET | `/api/me/:email` | None | Public profile |
 | GET | `/api/download-pdf` | Token via query | Export PDF |
+| GET | `/api-docs` | None | Swagger UI (OpenAPI docs) |
+| GET | `/api-docs.json` | None | Raw OpenAPI spec (JSON) |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "pug": "^3.0.2",
         "puppeteer": "^22.13.1",
         "redis": "^4.6.0",
+        "swagger-jsdoc": "^6.3.0",
+        "swagger-ui-express": "^5.0.1",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0"
       },
@@ -48,6 +50,8 @@
         "@types/jsonwebtoken": "^9.0.6",
         "@types/mongoose": "^5.11.97",
         "@types/node": "^20.14.12",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "@types/winston": "^2.4.4",
         "babel-plugin-module-resolver": "^5.0.0",
         "jest": "^29.7.0",
@@ -71,6 +75,90 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-14.0.1.tgz",
+      "integrity": "sha512-Oc96zvmxx1fqoSEdUmfmvvb59/KDOnUoJ7s2t7bISyAn0XEz57LCCw8k2Y4Pf3mwKaZLMciESALORLgfe2frCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-12.1.0.tgz",
+      "integrity": "sha512-e5mJoswsnAX0jG+J09xHFYQXb/bUc5S3pLpMxUuRUA2H8T2kni3yEoyz2R3Dltw5f4A6j6rPNMpWTK+iVDFlng==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "14.0.1",
+        "@apidevtools/openapi-schemas": "^2.1.0",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "ajv": "^8.17.1",
+        "ajv-draft-04": "^1.0.0",
+        "call-me-maybe": "^1.0.2"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/ajv-draft-04": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ajv-draft-04/-/ajv-draft-04-1.0.0.tgz",
+      "integrity": "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^8.5.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@apidevtools/swagger-parser/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@babel/cli": {
       "version": "7.25.9",
@@ -2214,6 +2302,15 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -2915,6 +3012,13 @@
         "@redis/client": "^1.0.0"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
@@ -3227,9 +3331,7 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.7",
@@ -3312,6 +3414,24 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -4245,6 +4365,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4716,10 +4842,9 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
-      "dev": true,
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5043,6 +5168,18 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/doctypes": {
@@ -5872,9 +6009,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-fifo": {
       "version": "1.3.2",
@@ -5896,6 +6031,22 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -6120,6 +6271,34 @@
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/forwarded": {
@@ -7320,7 +7499,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -7444,6 +7622,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jake": {
@@ -8485,6 +8678,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "license": "MIT"
+    },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -9248,6 +9447,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9367,6 +9573,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -9445,7 +9657,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10268,6 +10479,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
@@ -10574,7 +10794,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10587,7 +10806,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10976,6 +11194,153 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.3.0.tgz",
+      "integrity": "sha512-I+iQjVGV3t28pOkQUJv2MncthvOtkEactOn8R76SvSYhxgtIn7FoqfDHwQaN+GBnQdXQLrhgDXseKitmJcHMsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "^12.1.0",
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "11.1.0",
+        "lodash.mergewith": "^4.6.2",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.12",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.12.tgz",
+      "integrity": "sha512-ceXE+KNc5LXafhh36trB6nxK+U2EIKUWzHT7sBiMosf2eJLAefalYnTwMouQBmSyED6m7Yz+GYZEcL+Glt3sww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/tar": {
@@ -11685,7 +12050,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -11912,6 +12276,15 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "pug": "^3.0.2",
     "puppeteer": "^22.13.1",
     "redis": "^4.6.0",
+    "swagger-jsdoc": "^6.3.0",
+    "swagger-ui-express": "^5.0.1",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0"
   },
@@ -66,6 +68,8 @@
     "@types/jsonwebtoken": "^9.0.6",
     "@types/mongoose": "^5.11.97",
     "@types/node": "^20.14.12",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "@types/winston": "^2.4.4",
     "babel-plugin-module-resolver": "^5.0.0",
     "jest": "^29.7.0",

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -3,3 +3,4 @@ export * from '@/config/joi.config';
 export * from '@/config/process.config';
 export * from '@/config/regex.config';
 export * from '@/config/session.config';
+export * from '@/config/swagger.config';

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -1,0 +1,210 @@
+/**
+ * Author: Đạt Võ - https://github.com/datvt243
+ * Date: `--/--`
+ * Description: OpenAPI/Swagger spec generation config
+ */
+
+import swaggerJsdoc from 'swagger-jsdoc';
+import path from 'path';
+
+// swagger-jsdoc reads route files at runtime; resolve the right extension
+// whether running via ts-node (dev, .ts) or the compiled build (prod, .js)
+const ext = __filename.endsWith('.ts') ? 'ts' : 'js';
+
+const options: swaggerJsdoc.Options = {
+  definition: {
+    openapi: '3.0.3',
+    info: {
+      title: 'Resume API',
+      version: '1.0.0',
+      description: 'REST API for managing candidate CVs/resumes with auth, PDF export, and Redis caching.',
+    },
+    servers: [{ url: '/', description: 'Current server' }],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        ApiResponse: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean' },
+            message: { type: 'string' },
+            errors: { nullable: true },
+            data: { nullable: true },
+          },
+        },
+        SocialMedia: {
+          type: 'object',
+          properties: {
+            github: { type: 'string' },
+            linkedin: { type: 'string' },
+            website: { type: 'string' },
+          },
+        },
+        Candidate: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            email: { type: 'string', format: 'email' },
+            firstName: { type: 'string' },
+            lastName: { type: 'string' },
+            gender: { type: 'boolean' },
+            marital: { type: 'boolean' },
+            birthday: { type: 'number', description: 'Unix timestamp' },
+            address: { type: 'string' },
+            phone: { type: 'string' },
+            introduction: { type: 'string' },
+            socialMedia: { $ref: '#/components/schemas/SocialMedia' },
+          },
+        },
+        AuthRegisterRequest: {
+          type: 'object',
+          required: ['email', 'password'],
+          properties: {
+            email: { type: 'string', format: 'email' },
+            password: { type: 'string', format: 'password' },
+          },
+        },
+        AuthLoginRequest: {
+          type: 'object',
+          required: ['email', 'password'],
+          properties: {
+            email: { type: 'string', format: 'email' },
+            password: { type: 'string', format: 'password' },
+          },
+        },
+        AuthTokenResponse: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean' },
+            message: { type: 'string' },
+            data: {
+              type: 'object',
+              properties: {
+                token: { type: 'string' },
+                tokenRefresh: { type: 'string' },
+                user: { $ref: '#/components/schemas/Candidate' },
+              },
+            },
+          },
+        },
+        Experience: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            company: { type: 'string' },
+            position: { type: 'string' },
+            startDate: { type: 'number' },
+            endDate: { type: 'number' },
+            isCurrent: { type: 'boolean' },
+            description: { type: 'string' },
+            skills: { type: 'array', items: { type: 'string' } },
+          },
+        },
+        Education: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            school: { type: 'string' },
+            major: { type: 'string' },
+            startDate: { type: 'number' },
+            endDate: { type: 'number' },
+            isCurrent: { type: 'boolean' },
+            description: { type: 'string' },
+          },
+        },
+        Award: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            name: { type: 'string' },
+            organization: { type: 'string' },
+            issueDate: { type: 'number' },
+            link: { type: 'string' },
+            images: { type: 'array', items: { type: 'string' } },
+            description: { type: 'string' },
+          },
+        },
+        Certificate: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            name: { type: 'string' },
+            organization: { type: 'string' },
+            description: { type: 'string' },
+            startDate: { type: 'number' },
+            endDate: { type: 'number' },
+            isNoExpiration: { type: 'boolean' },
+            link: { type: 'string' },
+            images: { type: 'array', items: { type: 'string' } },
+          },
+        },
+        Project: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            name: { type: 'string' },
+            description: { type: 'string' },
+            position: { type: 'string' },
+            technology: { type: 'array', items: { type: 'string' } },
+            images: { type: 'array', items: { type: 'string' } },
+            link: { type: 'string' },
+            isWorking: { type: 'boolean' },
+            startDate: { type: 'number' },
+            endDate: { type: 'number' },
+          },
+        },
+        Reference: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            fullName: { type: 'string' },
+            phone: { type: 'string' },
+            company: { type: 'string' },
+            position: { type: 'string' },
+          },
+        },
+        GeneralInformation: {
+          type: 'object',
+          properties: {
+            _id: { type: 'string' },
+            candidateId: { type: 'string' },
+            positionDesired: { type: 'string' },
+            career: { type: 'string' },
+            levelCurrent: { type: 'string' },
+            levelDesired: { type: 'string' },
+            salaryDesired: { type: 'number' },
+            education: { type: 'string' },
+            yearsOfExperience: { type: 'number' },
+            workLocation: { type: 'string' },
+            workForm: { type: 'string' },
+            careerGoal: { type: 'string' },
+            personalSkills: { type: 'array', items: { type: 'object' } },
+            professionalSkills: { type: 'array', items: { type: 'object' } },
+            professionalSkillsGroup: { type: 'array', items: { type: 'string' } },
+            foreignLanguages: { type: 'array', items: { type: 'object' } },
+          },
+        },
+      },
+    },
+    security: [{ bearerAuth: [] }],
+  },
+  apis: [
+    path.join(__dirname, `../routers/**/*.${ext}`),
+    path.join(__dirname, `../candidate_me/*.${ext}`),
+    path.join(__dirname, `../server.${ext}`),
+  ],
+};
+
+export const swaggerSpec = swaggerJsdoc(options);

--- a/src/routers/api/v1/auth.route.ts
+++ b/src/routers/api/v1/auth.route.ts
@@ -14,9 +14,98 @@ import { createRateLimiter } from '@/middlewares/rateLimit.middleware';
 const authLimiter = createRateLimiter({ max: 150, windowMs: 15 * 60 * 1000, keyPrefix: 'auth-rl' });
 router.use(authLimiter);
 
+/**
+ * @swagger
+ * /api/v1/auth/register:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Register a new candidate account
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthRegisterRequest'
+ *     responses:
+ *       200:
+ *         description: Registration successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error or email already exists
+ */
 router.post('/register', authRegister);
+
+/**
+ * @swagger
+ * /api/v1/auth/login:
+ *   get:
+ *     tags: [Auth]
+ *     summary: Log in and receive access + refresh tokens
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthLoginRequest'
+ *     responses:
+ *       200:
+ *         description: Login successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthTokenResponse'
+ *       401:
+ *         description: Invalid credentials
+ */
 router.get('/login', authLogin);
+
+/**
+ * @swagger
+ * /api/v1/auth/logout:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Log out and blacklist the current access token
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Logout successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.post('/logout', authLogout);
+
+/**
+ * @swagger
+ * /api/v1/auth/refresh:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Rotate access/refresh tokens using a valid refresh token
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [refreshToken]
+ *             properties:
+ *               refreshToken:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: New token pair issued
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthTokenResponse'
+ *       401:
+ *         description: Invalid, expired, or revoked refresh token
+ */
 router.post('/refresh', authRefreshToken);
 
 export default router;

--- a/src/routers/api/v1/award.route.ts
+++ b/src/routers/api/v1/award.route.ts
@@ -11,6 +11,29 @@ import { fnCreate, fnUpdate } from '@/candidate_profile/awards/award.controller'
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/award:
+ *   get:
+ *     tags: [Award]
+ *     summary: List all awards for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of awards
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Award'
+ */
 router.get(
   '/',
   (req: Request, res: Response, next: NextFunction) => {
@@ -19,8 +42,81 @@ router.get(
   },
   baseGetAll,
 );
+
+/**
+ * @swagger
+ * /api/v1/award/create:
+ *   post:
+ *     tags: [Award]
+ *     summary: Create a new award entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Award'
+ *     responses:
+ *       201:
+ *         description: Award created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/award/update:
+ *   put:
+ *     tags: [Award]
+ *     summary: Update an existing award entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Award'
+ *     responses:
+ *       200:
+ *         description: Award updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/award/delete/{id}:
+ *   delete:
+ *     tags: [Award]
+ *     summary: Delete an award entry by ID
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Award deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.delete(
   '/delete/:id',
   (req: Request, res: Response, next: NextFunction) => {

--- a/src/routers/api/v1/candidate.route.ts
+++ b/src/routers/api/v1/candidate.route.ts
@@ -9,8 +9,86 @@ const router = express.Router();
 
 import { fnGetInformationByEmail, fnUpdate, fnUpdateFields } from '@/candidate/candidate.controller';
 
+/**
+ * @swagger
+ * /api/v1/candidate/{email}:
+ *   get:
+ *     tags: [Candidate]
+ *     summary: Get candidate profile by email
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: email
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: email
+ *     responses:
+ *       200:
+ *         description: Candidate profile
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/Candidate'
+ */
 router.get('/:email', fnGetInformationByEmail);
+
+/**
+ * @swagger
+ * /api/v1/candidate/update:
+ *   put:
+ *     tags: [Candidate]
+ *     summary: Fully update the authenticated candidate's profile
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Candidate'
+ *     responses:
+ *       200:
+ *         description: Candidate updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/candidate/update:
+ *   patch:
+ *     tags: [Candidate]
+ *     summary: Partially update the authenticated candidate's profile
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Candidate'
+ *     responses:
+ *       200:
+ *         description: Candidate updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.patch('/update', fnUpdateFields);
 
 export default router;

--- a/src/routers/api/v1/certificate.route.ts
+++ b/src/routers/api/v1/certificate.route.ts
@@ -11,6 +11,29 @@ import { fnCreate, fnUpdate } from '@/candidate_profile/certificates/certificate
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/certificate:
+ *   get:
+ *     tags: [Certificate]
+ *     summary: List all certificates for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of certificates
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Certificate'
+ */
 router.get(
   '/',
   (req: Request, res: Response, next: NextFunction) => {
@@ -19,8 +42,81 @@ router.get(
   },
   baseGetAll,
 );
+
+/**
+ * @swagger
+ * /api/v1/certificate/create:
+ *   post:
+ *     tags: [Certificate]
+ *     summary: Create a new certificate entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Certificate'
+ *     responses:
+ *       201:
+ *         description: Certificate created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/certificate/update:
+ *   put:
+ *     tags: [Certificate]
+ *     summary: Update an existing certificate entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Certificate'
+ *     responses:
+ *       200:
+ *         description: Certificate updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/certificate/delete/{id}:
+ *   delete:
+ *     tags: [Certificate]
+ *     summary: Delete a certificate entry by ID
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Certificate deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.delete(
   '/delete/:id',
   (req: Request, res: Response, next: NextFunction) => {

--- a/src/routers/api/v1/education.route.ts
+++ b/src/routers/api/v1/education.route.ts
@@ -11,6 +11,29 @@ import { fnCreate, fnUpdate } from '@/candidate_profile/education/education.cont
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/education:
+ *   get:
+ *     tags: [Education]
+ *     summary: List all education entries for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of education entries
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Education'
+ */
 router.get(
   '/',
   (req: Request, res: Response, next: NextFunction) => {
@@ -19,8 +42,81 @@ router.get(
   },
   baseGetAll,
 );
+
+/**
+ * @swagger
+ * /api/v1/education/create:
+ *   post:
+ *     tags: [Education]
+ *     summary: Create a new education entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Education'
+ *     responses:
+ *       201:
+ *         description: Education entry created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/education/update:
+ *   put:
+ *     tags: [Education]
+ *     summary: Update an existing education entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Education'
+ *     responses:
+ *       200:
+ *         description: Education entry updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/education/delete/{id}:
+ *   delete:
+ *     tags: [Education]
+ *     summary: Delete an education entry by ID
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Education entry deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.delete(
   '/delete/:id',
   (req: Request, res: Response, next: NextFunction) => {

--- a/src/routers/api/v1/experience.route.ts
+++ b/src/routers/api/v1/experience.route.ts
@@ -11,6 +11,29 @@ import { fnCreate, fnUpdate } from '@/candidate_profile/experience/experience.co
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/experience:
+ *   get:
+ *     tags: [Experience]
+ *     summary: List all work experience entries for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of experience entries
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Experience'
+ */
 router.get(
   '/',
   (req: Request, res: Response, next: NextFunction) => {
@@ -19,8 +42,81 @@ router.get(
   },
   baseGetAll,
 );
+
+/**
+ * @swagger
+ * /api/v1/experience/create:
+ *   post:
+ *     tags: [Experience]
+ *     summary: Create a new work experience entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Experience'
+ *     responses:
+ *       201:
+ *         description: Experience entry created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/experience/update:
+ *   put:
+ *     tags: [Experience]
+ *     summary: Update an existing work experience entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Experience'
+ *     responses:
+ *       200:
+ *         description: Experience entry updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/experience/delete/{id}:
+ *   delete:
+ *     tags: [Experience]
+ *     summary: Delete a work experience entry by ID
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Experience entry deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.delete(
   '/delete/:id',
   (req: Request, res: Response, next: NextFunction) => {

--- a/src/routers/api/v1/generalInformation.route.ts
+++ b/src/routers/api/v1/generalInformation.route.ts
@@ -9,9 +9,105 @@ import { fnGet, fnCreate, fnUpdate, fnUpdateFields } from '@/candidate_profile/g
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/general-information:
+ *   get:
+ *     tags: [GeneralInformation]
+ *     summary: Get general information for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: General information
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       $ref: '#/components/schemas/GeneralInformation'
+ */
 router.get('/', fnGet);
+
+/**
+ * @swagger
+ * /api/v1/general-information/create:
+ *   post:
+ *     tags: [GeneralInformation]
+ *     summary: Create general information (one per candidate)
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/GeneralInformation'
+ *     responses:
+ *       201:
+ *         description: General information created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error, or candidate already has general information
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/general-information/update:
+ *   put:
+ *     tags: [GeneralInformation]
+ *     summary: Fully replace general information
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/GeneralInformation'
+ *     responses:
+ *       200:
+ *         description: General information updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/general-information/update:
+ *   patch:
+ *     tags: [GeneralInformation]
+ *     summary: Partially update general information
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/GeneralInformation'
+ *     responses:
+ *       200:
+ *         description: General information updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.patch('/update', fnUpdateFields);
 
 export default router;

--- a/src/routers/api/v1/index.ts
+++ b/src/routers/api/v1/index.ts
@@ -30,6 +30,31 @@ router.use('/reference', verifyToken, routeReference);
 router.use('/general-information', verifyToken, routeGeneralInformation);
 router.use('/project', verifyToken, routeProject);
 router.use('/certificate', verifyToken, routeCertificate);
+
+/**
+ * @swagger
+ * /api/v1/download-pdf:
+ *   get:
+ *     tags: [CandidateMe]
+ *     summary: Export the authenticated candidate's CV as a PDF
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: token
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: Access token (token is read from the query string for this endpoint)
+ *     responses:
+ *       200:
+ *         description: PDF file stream
+ *         content:
+ *           application/pdf:
+ *             schema:
+ *               type: string
+ *               format: binary
+ */
 router.get('/download-pdf', verifyTokenByQuery, fnExportPDF);
 
 router.get('/*', (req, res) => {

--- a/src/routers/api/v1/project.route.ts
+++ b/src/routers/api/v1/project.route.ts
@@ -11,6 +11,29 @@ import { fnCreate, fnUpdate } from '@/candidate_profile/project/project.controll
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/project:
+ *   get:
+ *     tags: [Project]
+ *     summary: List all projects for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of projects
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Project'
+ */
 router.get(
   '/',
   (req: Request, res: Response, next: NextFunction) => {
@@ -19,8 +42,81 @@ router.get(
   },
   baseGetAll,
 );
+
+/**
+ * @swagger
+ * /api/v1/project/create:
+ *   post:
+ *     tags: [Project]
+ *     summary: Create a new project entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Project'
+ *     responses:
+ *       201:
+ *         description: Project created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/project/update:
+ *   put:
+ *     tags: [Project]
+ *     summary: Update an existing project entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Project'
+ *     responses:
+ *       200:
+ *         description: Project updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/project/delete/{id}:
+ *   delete:
+ *     tags: [Project]
+ *     summary: Delete a project entry by ID
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Project deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.delete(
   '/delete/:id',
   (req: Request, res: Response, next: NextFunction) => {

--- a/src/routers/api/v1/reference.route.ts
+++ b/src/routers/api/v1/reference.route.ts
@@ -11,6 +11,29 @@ import { fnCreate, fnUpdate } from '@/candidate_profile/reference_information/re
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /api/v1/reference:
+ *   get:
+ *     tags: [Reference]
+ *     summary: List all references for the authenticated candidate
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: List of references
+ *         content:
+ *           application/json:
+ *             schema:
+ *               allOf:
+ *                 - $ref: '#/components/schemas/ApiResponse'
+ *                 - type: object
+ *                   properties:
+ *                     data:
+ *                       type: array
+ *                       items:
+ *                         $ref: '#/components/schemas/Reference'
+ */
 router.get(
   '/',
   (req: Request, res: Response, next: NextFunction) => {
@@ -19,8 +42,81 @@ router.get(
   },
   baseGetAll,
 );
+
+/**
+ * @swagger
+ * /api/v1/reference/create:
+ *   post:
+ *     tags: [Reference]
+ *     summary: Create a new reference entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Reference'
+ *     responses:
+ *       201:
+ *         description: Reference created
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.post('/create', fnCreate);
+
+/**
+ * @swagger
+ * /api/v1/reference/update:
+ *   put:
+ *     tags: [Reference]
+ *     summary: Update an existing reference entry
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Reference'
+ *     responses:
+ *       200:
+ *         description: Reference updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Validation error
+ */
 router.put('/update', fnUpdate);
+
+/**
+ * @swagger
+ * /api/v1/reference/delete/{id}:
+ *   delete:
+ *     tags: [Reference]
+ *     summary: Delete a reference entry by ID
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Reference deleted
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
 router.delete(
   '/delete/:id',
   (req: Request, res: Response, next: NextFunction) => {

--- a/src/routers/index.ts
+++ b/src/routers/index.ts
@@ -24,6 +24,30 @@ router.use('/api/v2', routerAPIV2);
 /**
  * get ME
  */
+
+/**
+ * @swagger
+ * /api/me/{email}:
+ *   get:
+ *     tags: [CandidateMe]
+ *     summary: Get a candidate's full public profile (CV) by email, no auth required
+ *     parameters:
+ *       - in: path
+ *         name: email
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: email
+ *     responses:
+ *       200:
+ *         description: Aggregated public profile (candidate + general information + all CV sections)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Email not found
+ */
 router.get('/api/me/:email', fnGetAboutMe);
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,10 +12,11 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import cors from 'cors';
 import session from 'express-session';
+import swaggerUi from 'swagger-ui-express';
 /* import exitHook from 'exit-hook'; */
 
 import { errorsMiddleware, rateLimitMiddleware, startMemStoreCleanup, requestLogger } from '@/middlewares';
-import { sessionConfig, corsConfig } from '@/config';
+import { sessionConfig, corsConfig, swaggerSpec } from '@/config';
 import { logger } from '@/logger';
 import router from '@/routers';
 import { initRedis } from '@/services/redis';
@@ -47,6 +48,29 @@ const runServer = async ({ portNumber }: { portNumber: number }) => {
   app.use(bodyParser.urlencoded({ extended: true }));
   app.use(bodyParser.json());
 
+  /**
+   * @swagger
+   * /health:
+   *   get:
+   *     tags: [Health]
+   *     summary: Health check
+   *     responses:
+   *       200:
+   *         description: Service is healthy
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: ok
+   *                 timestamp:
+   *                   type: string
+   *                   format: date-time
+   *                 uptime:
+   *                   type: number
+   */
   // Health check endpoint (exempt from rate limiting)
   app.get('/health', (req, res) => {
     res.status(200).json({
@@ -54,6 +78,15 @@ const runServer = async ({ portNumber }: { portNumber: number }) => {
       timestamp: new Date().toISOString(),
       uptime: process.uptime(),
     });
+  });
+
+  /**
+   * API documentation (Swagger UI) - exempt from rate limiting
+   */
+  app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+  app.get('/api-docs.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(swaggerSpec);
   });
 
   /**


### PR DESCRIPTION
## Summary
- Add `swagger-jsdoc` + `swagger-ui-express` (and their `@types`) as dependencies.
- `src/config/swagger.config.ts` builds an OpenAPI 3.0.3 spec: a `bearerAuth` (JWT) security scheme, and reusable component schemas for every model (`Candidate`, `Experience`, `Education`, `Award`, `Certificate`, `Project`, `Reference`, `GeneralInformation`) plus auth request/response shapes and a generic `ApiResponse` envelope matching the app's actual response format.
- Mount Swagger UI at `GET /api-docs` and the raw spec at `GET /api-docs.json` in `server.ts`, placed before the rate limiter (same exemption as `/health`).
- Document all 36 endpoints with `@swagger` JSDoc blocks directly above each route: the 6 uniform CV-section routers (experience, education, award, certificate, project, reference), `generalInformation`, `candidate`, `auth`, the public `/api/me/:email` and `/api/v1/download-pdf` routes, and `/health`.
- The `apis` glob in `swagger.config.ts` resolves `.ts` vs `.js` at runtime so it works both under `ts-node` (dev) and the compiled `dist/` build (prod).

Verified the spec generates correctly and picks up every annotated route by loading `swaggerSpec` directly via `ts-node` (couldn't start the full server in this sandbox — see test plan) — 36/36 documented paths present, all component schemas resolved.

## Test plan
- [x] Loaded `swaggerSpec` directly (`ts-node -e "require('./src/config/swagger.config')"`) — confirms all 36 `@swagger` JSDoc blocks are parsed and every `$ref` resolves
- [x] `tsc --noEmit` under a `module: Node16` override — no new type errors (pre-existing `@/utils/querySafe` resolution errors are identical before/after and unrelated)
- [x] `npm test` — identical result before/after (11/11 runnable tests pass; 6 suites fail on a pre-existing, unrelated `jsonwebtoken`/Node-version native-module issue in this sandbox that also blocks starting the dev server here)
- [ ] Manually browse `/api-docs` in a browser against a running instance (not run — dev server can't start in this sandbox due to the `jsonwebtoken` issue above, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)