### PR TITLE
fix: add POST /api/v1/auth/login route

### DIFF
--- a/src/routers/api/v1/auth.route.ts
+++ b/src/routers/api/v1/auth.route.ts
@@ -10,6 +10,7 @@ const router = express.Router();
 import { authRegister, authLogin } from '@/auth/auth.controller';
 
 router.post('/register', authRegister);
+router.post('/login', authLogin);
 router.get('/login', authLogin);
 
 export default router;


### PR DESCRIPTION
## Summary
- Adds `router.post('/login', authLogin)` to `src/routers/api/v1/auth.route.ts` so `POST /api/v1/auth/login` works.
- Keeps the existing `GET /login` route for backward compatibility.

## Why
Frontend (`vue-resume-web`) switched login from GET to POST to stop leaking the password in the query string (see vue-resume-web#2 / PR vue-resume-web#22), and now calls `POST /api/v1/auth/login`. That route didn't exist on `v1` (only on `v2`), so login was returning 404.

Closes #45

## Test plan
- [x] Confirmed `authLogin` controller already reads credentials from `req.body`, so no controller/service changes needed.
- [ ] Manual: `curl -X POST https://nodejs-resume-api-ts.onrender.com/api/v1/auth/login -d '{"email":"...","password":"..."}'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)