### PR TITLE
fix: add POST /api/v1/auth/login route (mirror #46 on develop)

### DIFF
--- a/src/routers/api/v1/auth.route.ts
+++ b/src/routers/api/v1/auth.route.ts
@@ -41,7 +41,7 @@ router.post('/register', authRegister);
 /**
  * @swagger
  * /api/v1/auth/login:
- *   get:
+ *   post:
  *     tags: [Auth]
  *     summary: Log in and receive access + refresh tokens
  *     requestBody:
@@ -59,7 +59,27 @@ router.post('/register', authRegister);
  *               $ref: '#/components/schemas/AuthTokenResponse'
  *       401:
  *         description: Invalid credentials
+ *   get:
+ *     tags: [Auth]
+ *     summary: Log in and receive access + refresh tokens (deprecated, use POST)
+ *     deprecated: true
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/AuthLoginRequest'
+ *     responses:
+ *       200:
+ *         description: Login successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/AuthTokenResponse'
+ *       401:
+ *         description: Invalid credentials
  */
+router.post('/login', authLogin);
 router.get('/login', authLogin);
 
 /**


### PR DESCRIPTION
## Summary
- Mirrors the fix from #46 (already merged to `main`) onto `develop`, since `develop` never had it.
- Adds `router.post('/login', authLogin)`, keeps `GET /login` (deprecated) for backward compatibility.

## Why
`main` and `develop` had diverged (`main` was ~40 commits behind `develop`). Before merging `develop` into `main` to sync them, this closes the gap so no branch loses the login fix.

Related: #45, #46