### PR TITLE
fix: revert tsconfig moduleResolution to node, seed jest env vars (mirror #49)

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'jest';
 const config: Config = {
   verbose: true,
   roots: ['<rootDir>/src'],
+  setupFiles: ['<rootDir>/jest.setup.ts'],
   transform: {
     '^.+\\.tsx?$': 'ts-jest',
   },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,7 @@
+process.env.NODE_ENV ??= 'test';
+process.env.MONGOBD_USER ??= 'test-user';
+process.env.MONGOBD_PASSWORD ??= 'test-password';
+process.env.SESSION_SECRET ??= 'test-session-secret';
+process.env.TOKEN_SECRET ??= 'test-token-secret';
+process.env.TOKEN_REFRESH ??= 'test-token-refresh-secret';
+process.env.TOKEN_EXP_IN ??= '7d';

--- a/src/__tests__/middlewares/requestLogger.test.ts
+++ b/src/__tests__/middlewares/requestLogger.test.ts
@@ -1,0 +1,38 @@
+import { requestLogger } from '@/middlewares/requestLogger.middleware';
+import * as utils from '@/utils';
+
+jest.mock('@/utils', () => ({
+  _log: jest.fn(),
+}));
+
+function createMocks() {
+  const handlers: Record<string, () => void> = {};
+  const req: any = { method: 'GET', originalUrl: '/health' };
+  const res: any = {
+    statusCode: 200,
+    on: jest.fn((event: string, handler: () => void) => {
+      handlers[event] = handler;
+    }),
+  };
+  const next = jest.fn();
+  return { req, res, next, finish: () => handlers.finish() };
+}
+
+describe('requestLogger middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls next immediately', () => {
+    const { req, res, next } = createMocks();
+    requestLogger(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('logs method, url, status and duration when the response finishes', () => {
+    const { req, res, next, finish } = createMocks();
+    requestLogger(req, res, next);
+    finish();
+    expect(utils._log).toHaveBeenCalledWith(expect.stringContaining('GET /health 200'));
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "types": ["jest", "node"],
     "target": "ES2020", // Cấp độ ECMAScript mà mã sẽ được biên dịch tới
     "module": "CommonJS", // Định dạng module, sử dụng ES modules (import/export)
-    "moduleResolution": "node16",
+    "moduleResolution": "node",
     "outDir": "./dist", // Thư mục đầu ra của file JavaScript biên dịch
     "rootDir": "./src", // Thư mục gốc của mã nguồn TypeScript
     "esModuleInterop": true, // Hỗ trợ import module theo chuẩn CommonJS


### PR DESCRIPTION
## Summary
Mirrors #49 (already merged to `main`) onto `develop`:
- `tsconfig.json`: `moduleResolution: "node16"` + `module: "CommonJS"` is invalid (TS5110), broke `npm run build`.
- `jest.setup.ts` (new) + `jest.config.ts`: seed `TOKEN_SECRET`/`MONGOBD_USER`/etc so tests don't depend on a real `.env` being present. Fixes `auth.service.test.ts` and `mongo.db.ts` test failures that only showed up once the build stopped failing first.
- `requestLogger.test.ts`: was an empty file, made Jest fail the whole suite with "test suite must contain at least one test".

## Why
`node.js.yml` only triggers on `main`, so `develop` never got CI feedback on any of this — these bugs accumulated silently. Verified locally: `npm run build` succeeds, and the affected test files pass in isolation.