### PR TITLE
fix: fail deploy workflow when Render deploy hook errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,4 +21,4 @@ jobs:
 
       - name: Deploy to Render
         run: |
-          curl -X POST "https://api.render.com/deploy/srv-${{ secrets.RENDER_SRV }}?key=${{ secrets.RENDER_KEY }}"
+          curl -X POST --fail-with-body -sS "https://api.render.com/deploy/srv-${{ secrets.RENDER_SRV }}?key=${{ secrets.RENDER_KEY }}"


### PR DESCRIPTION
## Summary
- `curl -X POST` to the Render deploy hook has returned `Not Found` on every single run (checked today's runs and older ones) — the `RENDER_SRV`/`RENDER_KEY` secrets point to an invalid/stale service, so the live site has never actually been redeployed since its very first commit.
- The step never checked the HTTP response, so the job reported "success" regardless, masking the problem.
- Add `--fail-with-body -sS` so the job fails loudly and prints Render's error response whenever the deploy hook call doesn't succeed.

## Why
Discovered while verifying the recent CI fixes actually made it to production: `curl https://nodejs-resume-api-ts.onrender.com/health` returns a static "Hello World!" page (only present in the repo's very first commit), not the current JSON health response. This change won't fix the deploy itself (that requires updating the Render secrets — separate manual step), but it stops this from silently failing going forward.

## Test plan
- [ ] Next push to `main` should show this job fail (in red) until `RENDER_SRV`/`RENDER_KEY` are corrected in repo secrets — that's the intended, visible signal.