### PR TITLE
ci: allow manually triggering the Render deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main  # Thay 'main' bằng nhánh bạn muốn deploy
+  workflow_dispatch: {}
 
 jobs:
   deploy:


### PR DESCRIPTION
Adds `workflow_dispatch` to deploy.yml so we can re-test the Render deploy hook on demand (e.g. right now, after rotating RENDER_SRV/RENDER_KEY) without a dummy push to main.