### PR TITLE
fix: remove @types/mongoose and pin engines.node to unblock Render build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@types/http-status-codes": "^1.2.0",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.6",
-        "@types/mongoose": "^5.11.97",
         "@types/node": "^20.14.12",
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
@@ -3349,17 +3348,6 @@
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/mongoose": {
-      "version": "5.11.97",
-      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.11.97.tgz",
-      "integrity": "sha512-cqwOVYT3qXyLiGw7ueU2kX9noE8DPGRY6z8eUxudhXY8NZ7DMKYAxyZkLSevGfhCX3dO/AoX5/SO9lAzfjon0Q==",
-      "deprecated": "Mongoose publishes its own types, so you do not need to install this package.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mongoose": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.17.6",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
   },
   "author": "DatVT",
   "license": "ISC",
+  "engines": {
+    "node": ">=20.19.0"
+  },
   "dependencies": {
     "@babel/runtime": "^7.22.10",
     "bcrypt": "^5.1.1",
@@ -66,7 +69,6 @@
     "@types/http-status-codes": "^1.2.0",
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.6",
-    "@types/mongoose": "^5.11.97",
     "@types/node": "^20.14.12",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",


### PR DESCRIPTION
## Summary
- Render build log showed: \`error mongoose@9.9.3: The engine "node" is incompatible with this module. Expected version ">=20.19.0". Got "20.15.1"\`, aborting every deploy since forever.
- Root cause: \`@types/mongoose\` (deprecated devDependency, unused — mongoose ships its own types) declares an unpinned \`"mongoose": "*"\` dependency. Render's build uses Yarn without a committed \`yarn.lock\`, so Yarn independently resolved that wildcard to the newest mongoose (9.9.3) instead of reusing our pinned \`^8.4.0\`. That version requires Node >=20.19.0, which Render's runtime (20.15.1) doesn't satisfy.
- Fix: remove the unused \`@types/mongoose\` (eliminates the wildcard resolution entirely), and add \`engines.node\` so Render provisions a Node version that satisfies the whole dependency tree going forward.

## Why
This is the actual reason the live site (nodejs-resume-api-ts.onrender.com) has been stuck on an ancient build the whole time, even after #49/#51 fixed the GitHub Actions side.

## Test plan
- [x] \`npm run build\` succeeds locally after \`npm uninstall @types/mongoose\`
- [x] Confirmed no source file references \`@types/mongoose\`
- [ ] Next Render deploy should succeed and \`/health\` should return the JSON response