### PR TITLE
merge dev to main: bump version to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nodejs-resume-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nodejs-resume-api",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "ISC",
       "dependencies": {
         "@babel/runtime": "^7.22.10",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nodejs-resume-api",
   "main": "src/server.ts",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Resume API backend with rate limiting and Redis support",
   "scripts": {
     "dev-node": "ts-node -r tsconfig-paths/register src/server.ts",


### PR DESCRIPTION
## Summary
Sync main with develop — version bump to 1.1.0 (#68) reflecting today's security fixes and new self-delete endpoint (#64, #65, #66, #67).

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 45/45 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)