### PR TITLE
feat: add forgot-password / reset-password flow (issue #70)

### DIFF
--- a/src/__tests__/auth/auth.service.test.ts
+++ b/src/__tests__/auth/auth.service.test.ts
@@ -3,9 +3,10 @@
  */
 
 import CandidateModel from '@/models/candidate.model';
-import { handlerRegister, handlerLogin, isEmailAlreadyExists } from '@/auth/auth.service';
+import { handlerRegister, handlerLogin, isEmailAlreadyExists, handlerForgotPassword, handlerResetPassword } from '@/auth/auth.service';
 import * as bcrypt from '@/utils';
 import * as jwt from '@/utils';
+import { createResetToken, consumeResetToken } from '@/utils/passwordReset';
 
 // Mock modules
 jest.mock('@/models/candidate.model');
@@ -15,6 +16,13 @@ jest.mock('@/utils', () => ({
   bcryptGenerateSalt: jest.fn(),
   bcryptCompareHash: jest.fn(),
   jwtSign: jest.fn(),
+}));
+jest.mock('@/utils/passwordReset', () => ({
+  createResetToken: jest.fn(),
+  consumeResetToken: jest.fn(),
+}));
+jest.mock('@/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn() },
 }));
 
 describe('auth.service', () => {
@@ -132,6 +140,55 @@ describe('auth.service', () => {
       const result = await handlerLogin({ email: 'test@example.com', password: 'wrongpass' });
 
       expect(result).toEqual({ success: false, message: 'Mật khẩu không chính xác' });
+    });
+  });
+
+  describe('handlerForgotPassword', () => {
+    it('creates a reset token when the email exists', async () => {
+      const mockUser = { _id: { toString: () => 'user_id' }, email: 'test@example.com' };
+      (CandidateModel.findOne as jest.Mock).mockResolvedValue(mockUser);
+      (createResetToken as jest.Mock).mockResolvedValue('raw-token');
+
+      const result = await handlerForgotPassword('test@example.com');
+
+      expect(CandidateModel.findOne).toHaveBeenCalledWith({ email: 'test@example.com' });
+      expect(createResetToken).toHaveBeenCalledWith('user_id');
+      expect(result).toEqual({ success: true, message: 'Nếu email tồn tại, liên kết đặt lại mật khẩu đã được tạo' });
+    });
+
+    it('returns the same generic success message when the email does not exist (no user enumeration)', async () => {
+      (CandidateModel.findOne as jest.Mock).mockResolvedValue(null);
+
+      const result = await handlerForgotPassword('nonexistent@example.com');
+
+      expect(createResetToken).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: true, message: 'Nếu email tồn tại, liên kết đặt lại mật khẩu đã được tạo' });
+    });
+  });
+
+  describe('handlerResetPassword', () => {
+    it('updates the password when the reset token is valid', async () => {
+      const mockHash = '$2b$10$newhashedpassword';
+      (consumeResetToken as jest.Mock).mockResolvedValue('user_id');
+      (bcrypt.bcryptGenerateSalt as jest.Mock).mockResolvedValue(mockHash);
+      (CandidateModel.updateOne as jest.Mock).mockResolvedValue({ acknowledged: true });
+
+      const result = await handlerResetPassword({ token: 'raw-token', password: 'NewPass123!' });
+
+      expect(consumeResetToken).toHaveBeenCalledWith('raw-token');
+      expect(bcrypt.bcryptGenerateSalt).toHaveBeenCalledWith('NewPass123!');
+      expect(CandidateModel.updateOne).toHaveBeenCalledWith({ _id: 'user_id' }, { password: mockHash });
+      expect(result).toEqual({ success: true, message: 'Đặt lại mật khẩu thành công' });
+    });
+
+    it('fails without touching the password when the token is invalid/expired', async () => {
+      (consumeResetToken as jest.Mock).mockResolvedValue(null);
+
+      const result = await handlerResetPassword({ token: 'bad-token', password: 'NewPass123!' });
+
+      expect(bcrypt.bcryptGenerateSalt).not.toHaveBeenCalled();
+      expect(CandidateModel.updateOne).not.toHaveBeenCalled();
+      expect(result).toEqual({ success: false, message: 'Token đặt lại mật khẩu không hợp lệ hoặc đã hết hạn' });
     });
   });
 });

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -7,8 +7,8 @@ import { Request, Response, NextFunction } from 'express';
 import { StatusCodes } from 'http-status-codes';
 import { validateSchema, formatReturn, handleError, throwBadRequestError } from '@/utils';
 
-import { schemaAuthRegister, schemaAuthLogin } from './auth.validate';
-import { handlerRegister, handlerLogin } from './auth.service';
+import { schemaAuthRegister, schemaAuthLogin, schemaForgotPassword, schemaResetPassword } from './auth.validate';
+import { handlerRegister, handlerLogin, handlerForgotPassword, handlerResetPassword } from './auth.service';
 import { addToBlacklist, isBlacklisted } from '@/utils/tokenBlacklist';
 import { jwtSign, jwtVerify } from '@/utils';
 import { extractTokenFromRequest } from '@/utils/helper-auth';
@@ -150,6 +150,68 @@ export const authRefreshToken = async (req: Request, res: Response, next: NextFu
  */
 export const authCreateRefreshToken = async (req: Request, res: Response) => {
   // coming soon
+};
+
+/**
+ * Chức năng Quên mật khẩu: tạo reset token và (stub) log link đặt lại
+ */
+export const authForgotPassword = async (req: Request, res: Response, next: NextFunction) => {
+  const { isValidated, value = {}, errors, message } = validateSchema({
+    schema: schemaForgotPassword,
+    item: { ...req.body },
+    lang: (req as any).lang,
+  });
+  if (!isValidated) {
+    return formatReturn(res, {
+      statusCode: StatusCodes.BAD_REQUEST,
+      success: false,
+      message,
+      errors,
+    });
+  }
+
+  try {
+    const { success, message } = await handlerForgotPassword(value.email, (req as any).lang);
+    return formatReturn(res, {
+      statusCode: StatusCodes.OK,
+      success,
+      message,
+      data: null,
+    });
+  } catch (err) {
+    handleError(err, next, (req as any).lang);
+  }
+};
+
+/**
+ * Chức năng Đặt lại mật khẩu: xác thực reset token rồi cập nhật mật khẩu mới
+ */
+export const authResetPassword = async (req: Request, res: Response, next: NextFunction) => {
+  const { isValidated, value = {}, errors, message } = validateSchema({
+    schema: schemaResetPassword,
+    item: { ...req.body },
+    lang: (req as any).lang,
+  });
+  if (!isValidated) {
+    return formatReturn(res, {
+      statusCode: StatusCodes.BAD_REQUEST,
+      success: false,
+      message,
+      errors,
+    });
+  }
+
+  try {
+    const { success, message } = await handlerResetPassword({ token: value.token, password: value.password }, (req as any).lang);
+    return formatReturn(res, {
+      statusCode: StatusCodes[success ? 'OK' : 'BAD_REQUEST'],
+      success,
+      message,
+      data: null,
+    });
+  } catch (err) {
+    handleError(err, next, (req as any).lang);
+  }
 };
 
 /**

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,6 +8,8 @@ import CandidateModel from '@/models/candidate.model';
 import { bcryptGenerateSalt, bcryptCompareHash, jwtSign } from '@/utils';
 import { TOKEN_SECRET, TOKEN_REFRESH, TOKEN_EXP_IN, TOKEN_REFRESH_EXP_IN } from '@/config/process.config';
 import { t, DEFAULT_LANG } from '@/utils/i18n';
+import { createResetToken, consumeResetToken } from '@/utils/passwordReset';
+import { logger } from '@/logger';
 
 interface Auth {
   email: string;
@@ -94,4 +96,46 @@ export const handlerLogin = async (data: Auth, lang: string = DEFAULT_LANG) => {
     },
     errors: null,
   };
+};
+
+/**
+ * Chức năng Quên mật khẩu: tạo reset token cho email nếu tồn tại
+ *
+ * Luôn trả về message chung chung dù email có tồn tại hay không, để
+ * tránh lộ thông tin email nào đã đăng ký (user enumeration).
+ *
+ * STUB (issue #70): chưa có hạ tầng gửi email trong project — log link
+ * reset thay vì gửi email thật. Thay bằng mailer thật khi chọn được
+ * provider.
+ */
+export const handlerForgotPassword = async (email: string, lang: string = DEFAULT_LANG) => {
+  const user = await CandidateModel.findOne({ email });
+
+  if (user && user._id) {
+    const token = await createResetToken(user._id.toString());
+    logger.info(`[passwordReset] Reset link for ${email}: /reset-password?token=${token}`);
+  }
+
+  return { success: true, message: t('auth.forgotPasswordRequested', lang) };
+};
+
+interface ResetPasswordInput {
+  token: string;
+  password: string;
+}
+
+/**
+ * Chức năng Đặt lại mật khẩu: xác thực reset token (single-use) rồi
+ * cập nhật mật khẩu mới (bcrypt hash).
+ */
+export const handlerResetPassword = async (data: ResetPasswordInput, lang: string = DEFAULT_LANG) => {
+  const { token, password } = data;
+
+  const candidateId = await consumeResetToken(token);
+  if (!candidateId) return { success: false, message: t('auth.resetTokenInvalid', lang) };
+
+  const bcryptPwd = await bcryptGenerateSalt(password);
+  await CandidateModel.updateOne({ _id: candidateId }, { password: bcryptPwd });
+
+  return { success: true, message: t('auth.resetPasswordSuccess', lang) };
 };

--- a/src/auth/auth.validate.ts
+++ b/src/auth/auth.validate.ts
@@ -43,3 +43,18 @@ export const schemaAuthLogin = Joi.object({
   email,
   password,
 });
+
+export const schemaForgotPassword = Joi.object({
+  email,
+});
+
+export const schemaResetPassword = Joi.object({
+  token: Joi.string().trim().strict().required().messages({
+    'any.required': 'Token không được để trống',
+    'string.empty': 'Token không được để trống',
+  }),
+  password,
+  repassword: Joi.any().valid(Joi.ref('password')).required().messages({
+    'any.only': 'Password không khớp',
+  }),
+}).with('password', 'repassword');

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -16,6 +16,9 @@ export default {
     tokenRefreshed: 'Token refreshed',
     noTokenToLogout: 'No token provided to logout',
     logoutSuccess: 'Logged out successfully',
+    forgotPasswordRequested: 'If the email exists, a password reset link has been generated',
+    resetTokenInvalid: 'Password reset token is invalid or has expired',
+    resetPasswordSuccess: 'Password reset successful',
   },
   validation: {
     hasErrors: 'Validation has errors',

--- a/src/locales/vi.ts
+++ b/src/locales/vi.ts
@@ -16,6 +16,9 @@ export default {
     tokenRefreshed: 'Làm mới token thành công',
     noTokenToLogout: 'Không có token để đăng xuất',
     logoutSuccess: 'Đăng xuất thành công',
+    forgotPasswordRequested: 'Nếu email tồn tại, liên kết đặt lại mật khẩu đã được tạo',
+    resetTokenInvalid: 'Token đặt lại mật khẩu không hợp lệ hoặc đã hết hạn',
+    resetPasswordSuccess: 'Đặt lại mật khẩu thành công',
   },
   validation: {
     hasErrors: 'Dữ liệu không hợp lệ',

--- a/src/routers/api/v1/auth.route.ts
+++ b/src/routers/api/v1/auth.route.ts
@@ -7,7 +7,7 @@
 import express from 'express';
 const router = express.Router();
 
-import { authRegister, authLogin, authLogout, authRefreshToken } from '@/auth/auth.controller';
+import { authRegister, authLogin, authLogout, authRefreshToken, authForgotPassword, authResetPassword } from '@/auth/auth.controller';
 import { createRateLimiter } from '@/middlewares/rateLimit.middleware';
 
 // Apply rate limit for auth routes (150 requests per 15 minutes)
@@ -127,5 +127,63 @@ router.post('/logout', authLogout);
  *         description: Invalid, expired, or revoked refresh token
  */
 router.post('/refresh', authRefreshToken);
+
+/**
+ * @swagger
+ * /api/v1/auth/forgot-password:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Request a password reset (stub — no email is actually sent yet, see issue #70)
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email]
+ *             properties:
+ *               email:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Generic success response (same regardless of whether the email exists)
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ */
+router.post('/forgot-password', authForgotPassword);
+
+/**
+ * @swagger
+ * /api/v1/auth/reset-password:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Reset password using a reset token from /forgot-password
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [token, password, repassword]
+ *             properties:
+ *               token:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *               repassword:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Password reset successful
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ApiResponse'
+ *       400:
+ *         description: Invalid, expired, or already-used reset token
+ */
+router.post('/reset-password', authResetPassword);
 
 export default router;

--- a/src/utils/passwordReset.ts
+++ b/src/utils/passwordReset.ts
@@ -1,0 +1,85 @@
+/**
+ * Author: Đạt Võ - https://github.com/datvt243
+ * Date: `--/--`
+ * Description: Single-use, short-lived password reset tokens. Same
+ * Redis-with-in-memory-fallback TTL pattern as utils/tokenBlacklist.ts.
+ *
+ * NOTE (issue #70): no email-sending infra exists in this project yet.
+ * The reset link is logged instead of emailed — a stand-in until a mail
+ * provider is chosen. See auth.service.ts's handlerForgotPassword.
+ */
+
+import crypto from 'crypto';
+import { isRedisAvailable, getRedisClient } from '@/services/redis';
+import { logger } from '@/logger';
+
+type Entry = { candidateId: string; expiresAt: number };
+
+const RESET_TOKEN_TTL_SECONDS = 15 * 60; // 15 minutes, single-use
+
+// In-Memory fallback (used when Redis unavailable)
+const memoryStore = new Map<string, Entry>();
+
+// cleanup expired entries periodically (in-memory only)
+const _cleanup = setInterval(() => {
+  const now = Date.now() / 1000;
+  for (const [token, entry] of memoryStore) {
+    if (entry.expiresAt <= now) memoryStore.delete(token);
+  }
+}, 60 * 1000);
+// do not keep node process alive for tests
+if (typeof (_cleanup as any).unref === 'function') (_cleanup as any).unref();
+
+/**
+ * Generate a single-use reset token for a candidate and store it
+ * (Redis if available, else in-memory). Returns the raw token.
+ */
+export const createResetToken = async (candidateId: string): Promise<string> => {
+  const token = crypto.randomBytes(32).toString('hex');
+  const expiresAt = Math.floor(Date.now() / 1000) + RESET_TOKEN_TTL_SECONDS;
+
+  if (isRedisAvailable()) {
+    const redis = getRedisClient();
+    if (redis) {
+      await redis.setEx(`password-reset:${token}`, RESET_TOKEN_TTL_SECONDS, candidateId);
+      return token;
+    }
+  }
+
+  // Fallback: in-memory
+  memoryStore.set(token, { candidateId, expiresAt });
+  return token;
+};
+
+/**
+ * Verify a reset token and consume it in the same step — deleted whether
+ * valid or not, so a token can never be replayed. Returns the candidateId
+ * it was issued for, or null if missing/invalid/expired.
+ */
+export const consumeResetToken = async (token: string): Promise<string | null> => {
+  if (!token) return null;
+
+  try {
+    if (isRedisAvailable()) {
+      const redis = getRedisClient();
+      if (redis) {
+        const candidateId = await redis.get(`password-reset:${token}`);
+        if (candidateId !== null) await redis.del(`password-reset:${token}`);
+        return candidateId;
+      }
+    }
+
+    // Fallback: in-memory
+    const entry = memoryStore.get(token);
+    memoryStore.delete(token);
+    if (!entry) return null;
+    const now = Date.now() / 1000;
+    if (entry.expiresAt <= now) return null;
+    return entry.candidateId;
+  } catch (err) {
+    logger.error('[passwordReset] Error consuming reset token', { err: (err as Error).message, stack: (err as Error).stack });
+    return null;
+  }
+};
+
+export default { createResetToken, consumeResetToken };


### PR DESCRIPTION
Closes #70.

## Summary
- `POST /api/v1/auth/forgot-password` — generates a single-use, 15-min TTL reset token (Redis + in-memory fallback, same pattern as `utils/tokenBlacklist.ts`). Always returns the same generic response regardless of whether the email exists (no user enumeration).
- `POST /api/v1/auth/reset-password` — consumes the token (single-use, deleted on read either way), bcrypt-hashes the new password, updates `Candidate.password`.
- **Stub delivery**: no email-sending infra exists in this repo yet. The reset link is logged instead of emailed — an explicit, operator-approved scope decision (issue #70 itself flags the email-provider choice as needing its own discussion). Real delivery is a follow-up once a provider is chosen.

## Test plan
- `npm test` — 49/49 passing (4 new cases covering both handlers, including no-enumeration behavior and invalid/expired-token rejection).
- `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)