### PR TITLE
fix: render career/careerGoal fields in exported PDF (issue #87)

### DIFF
--- a/src/__tests__/services/createPDF.test.ts
+++ b/src/__tests__/services/createPDF.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for services/createPDF.ts's pageRender — pure HTML-building
+ * function, no Puppeteer involved, so it's safe/fast to test directly.
+ */
+
+import { pageRender } from '@/services/createPDF';
+
+describe('pageRender', () => {
+  it('renders career and careerGoal into the PDF content (issue #87)', () => {
+    const { html } = pageRender({
+      email: 'test@example.com',
+      firstName: 'John',
+      lastName: 'Doe',
+      generalInformation: {
+        career: 'Backend Developer',
+        careerGoal: 'Trở thành Tech Lead trong 3 năm tới',
+        personalSkills: [],
+        professionalSkills: [],
+      },
+    });
+
+    expect(html).toContain('Backend Developer');
+    expect(html).toContain('Trở thành Tech Lead trong 3 năm tới');
+    // _boxContent() uppercases its title heading — match the real output.
+    expect(html).toContain('ĐỊNH HƯỚNG NGHỀ NGHIỆP');
+  });
+
+  it('omits the career box entirely when both fields are empty', () => {
+    const { html } = pageRender({
+      email: 'test@example.com',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      generalInformation: {
+        career: '',
+        careerGoal: '',
+        personalSkills: [],
+        professionalSkills: [],
+      },
+    });
+
+    expect(html).not.toContain('ĐỊNH HƯỚNG NGHỀ NGHIỆP');
+  });
+
+  it('renders only whichever of career/careerGoal is present', () => {
+    const { html } = pageRender({
+      email: 'test@example.com',
+      firstName: 'Jane',
+      lastName: 'Doe',
+      generalInformation: {
+        career: 'QA Engineer',
+        careerGoal: '',
+        personalSkills: [],
+        professionalSkills: [],
+      },
+    });
+
+    expect(html).toContain('QA Engineer');
+    expect(html).toContain('ĐỊNH HƯỚNG NGHỀ NGHIỆP');
+    expect(html).not.toContain('Mục tiêu nghề nghiệp');
+  });
+});

--- a/src/services/createPDF.ts
+++ b/src/services/createPDF.ts
@@ -88,6 +88,7 @@ export const pageRender = (RECORD: Record<string, any>) => {
   const _ = _helper();
 
   _content += _.renderInfo(candidate);
+  _content += _.renderCareer(generalInformation);
   _content += _.renderSkills(generalInformation);
   _content += _.renderExperience(experiences);
   _content += _.renderProject(projects);
@@ -230,6 +231,21 @@ const _helper = () => {
                     </div>
                     <div class="description">${introduction}</div>
                 </div>`;
+    },
+    renderCareer: function (generalInformation: { career?: string; careerGoal?: string }) {
+      // `career`/`careerGoal` are localized ({vi,en}) fields at the model
+      // level, but by the time they reach here they've already been
+      // resolved to a single string upstream (candidate_me/index.ts's
+      // resolveLocalizedText) — same as every other field this function
+      // handles.
+      const { career = '', careerGoal = '' } = generalInformation || {};
+      if (!career && !careerGoal) return '';
+
+      let _result = '';
+      career && (_result += `<p><strong>Nghề nghiệp:</strong> ${career}</p>`);
+      careerGoal && (_result += `<p><strong>Mục tiêu nghề nghiệp:</strong> ${careerGoal}</p>`);
+
+      return _boxContent('Định hướng nghề nghiệp', _result);
     },
     renderSkills: function (generalInformation: {
       personalSkills: Skill[];


### PR DESCRIPTION
Closes #87.

## Summary
`generalInformation.career`/`careerGoal` were correctly resolved to plain strings on the public JSON response (multi-language resume content feature, #79) but `createPDF.ts` never rendered them into the exported PDF at all — silently dropped.

- `renderCareer()` added to `createPDF.ts`'s `_helper()`, same `_boxContent` pattern as every other section. Renders a "Định hướng nghề nghiệp" box right after basic info; omits the box when both fields are empty, omits either line individually when only one is set.
- `src/__tests__/services/createPDF.test.ts` — `pageRender` had zero test coverage before this; added 3 cases.

## Test plan
- `npm test` — 52/52 passing (10 suites, +3 new).
- `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)